### PR TITLE
Hotfix/padding/h text/maincss

### DIFF
--- a/main.css
+++ b/main.css
@@ -18,7 +18,7 @@ footer {
   justify-content: flex-start;
 }
 .h-text {
-  padding: -5%;
+  
   color: honeydew;
   font-size: 20px;
   padding: -5%;

--- a/main.css
+++ b/main.css
@@ -20,7 +20,7 @@ footer {
 .h-text {
   padding: -5%;
   color: honeydew;
-  font-size: 132%;
+  font-size: 20px;
   padding: -5%;
   padding-top: -81%;
   display: inline;


### PR DESCRIPTION
double padding code is removed in h-text in main.css
